### PR TITLE
Level 10 - 11 (12 level will be added here)

### DIFF
--- a/src/main/resources/io/jenkins/plugins/sample/OnboardingPluginBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/sample/OnboardingPluginBuilder/config.jelly
@@ -3,6 +3,7 @@
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Category}">
         <f:select field="categoryId"/>
+        Last job that run with selected category : ${instance.descriptor.getLastJobName(instance.category)}
     </f:entry>
 
     <f:section title="Last 5 builds">


### PR DESCRIPTION
- [ ] Per category, store the name of the last job when one of its “Onboarding tasks” is executed having that category selected.
That information can be stored in the same file as in level 8 or a different one, up to you.

- [ ] On the Global Configuration page, display the DisplayName of the last job that you stored in level 10.

- [ ] Support the renaming of a job, to be taken into account by the storage created in level 10.